### PR TITLE
chore(server): allow building with aeson 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for spacecookie
 
+## 1.0.0.1
+
+2021-11-29
+
+This release fixes compilation with `aeson >= 2.0`.
+
 ## 1.0.0.0
 
 2021-03-16

--- a/server/Network/Spacecookie/Config.hs
+++ b/server/Network/Spacecookie/Config.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP               #-}
 module Network.Spacecookie.Config
   ( Config (..)
   , LogConfig (..)
@@ -23,7 +24,13 @@ data Config
   , logConfig     :: LogConfig
   }
 
+-- We only use string literals with 'maybePath', so we can just switch between
+-- Key and Text, since both have an IsString instance for OverloadedStrings.
+#if MIN_VERSION_aeson(2,0,0)
+maybePath :: FromJSON a => [Key] -> Object -> Parser (Maybe a)
+#else
 maybePath :: FromJSON a => [Text] -> Object -> Parser (Maybe a)
+#endif
 maybePath []     _ = fail "got empty path"
 maybePath [x]    v = v .:? x
 maybePath (x:xs) v = v .:? x >>= fmap join . traverse (maybePath xs)

--- a/spacecookie.cabal
+++ b/spacecookie.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                spacecookie
-version:             1.0.0.0
+version:             1.0.0.1
 synopsis:            Gopher server library and daemon
 description:         Simple gopher library that allows writing custom gopher
                      applications. Also includes a fully-featured gopher server
@@ -52,7 +52,7 @@ executable spacecookie
   import:              common-settings, gopher-dependencies
   main-is:             Main.hs
   build-depends:       spacecookie
-                     , aeson >= 1.5 && < 2.0
+                     , aeson >= 1.5
                      , systemd >= 2.1.0
                      , fast-logger >= 2.4.0
   hs-source-dirs:      server


### PR DESCRIPTION
The actual change is a bit cheesy, since we could have a non-CPP
solution as well by adding a FromString constraint, but this one is
stupid and simple.

Additionally tested with both GHC 8.10.7, 9.0.1 and

    cabal v2-build --constraint='aeson >= 2.0'

Increase version number to 1.0.0.1 (no observable changes) for a release
that benefits Stackage Nightly mostly.

Resolves #51.